### PR TITLE
Perform intial sync when there is no cache file

### DIFF
--- a/sList.py
+++ b/sList.py
@@ -23,6 +23,8 @@ class List:
 				currentState=cacheData['currentState']
 				self.items=currentState['items']
 				self.title=currentState['title']
+			else:
+				self.sync()
 		else:
 			self.cache=None
 			self.sync()


### PR DESCRIPTION
Without this patch, trying to sync a list that isn't cached while caching is enabled will always lead to the error message “List creation is only supported online.”