### PR TITLE
Only perform sync after all changes are applied

### DIFF
--- a/shoppinglist/actions.py
+++ b/shoppinglist/actions.py
@@ -12,6 +12,7 @@ def addAction(sl,args):
 		for item in sys.stdin.readlines():
 			if not item.isspace():
 				sl.add(item)
+	sl.sync()
 	sl.show()
 		
 	
@@ -24,6 +25,7 @@ def delAction(sl,args):
 		itemsToDelete = itemsToDelete + [item]
 	for item in itemsToDelete:
 		sl.delete(item)
+	sl.sync()
 	sl.show()
 
 def editAction(sl,args):
@@ -31,10 +33,12 @@ def editAction(sl,args):
 	if(match < .8):
 		sys.exit('No matching item found: "{}"'.format(args.item))
 	sl.edit(item,' '.join(args.value))
+	sl.sync()
 	sl.show()
 
 def clearAction(sl,args):
 	sl.clear()
+	sl.sync()
 	sl.show()
 
 actionDict={

--- a/shoppinglist/sList.py
+++ b/shoppinglist/sList.py
@@ -85,10 +85,8 @@ class List:
 				print("- {}".format(itemStr(item,self.catList)))
 	def add(self,value):
 		self.items.append({'stringRepresentation':value, 'id': str(uuid.uuid4())})
-		self.sync()
 	def delete(self,item):
 		self.items.remove(item)
-		self.sync()
 	def edit(self,item,value):
 		if('id' in item):
 			itemId=item['id']
@@ -97,10 +95,8 @@ class List:
 		else:
 			item.clear()
 		item['stringRepresentation']=value
-		self.sync()
 	def clear(self):
 		self.items.clear()
-		self.sync()
 	def at(self, index):
 		if 0 < index <= len(self.items):
 			return self.items[index - 1]


### PR DESCRIPTION
Before, a sync would performed every time sList.add was called. This leads to repeated syncs when piping into `shoppinglist add` and a significant slowdown.

This commit moves the responsibility for syncing from sList to actions, so it can be called only once per action.